### PR TITLE
MER-3340 Allow custom configs from user code

### DIFF
--- a/melatonin_perfetto/melatonin_perfetto.h
+++ b/melatonin_perfetto/melatonin_perfetto.h
@@ -50,6 +50,11 @@ public:
         cfg.add_buffers()->set_size_kb (buffer_size_kb); // 80MB is the default
         auto* ds_cfg = cfg.add_data_sources()->mutable_config();
         ds_cfg->set_name ("track_event");
+        beginSession (cfg);
+    }
+
+    void beginSession (const perfetto::TraceConfig& cfg)
+    {
         session = perfetto::Tracing::NewTrace();
         session->Setup (cfg);
         session->StartBlocking();


### PR DESCRIPTION
This allows passing a custom config but may be moot if this isn't the way to do it for system tracing. In any case the change is benign. I have some other changes stashed, not least some that prevent a crash it `endSession()` is called without calling `beginSession()` since it derefences the `session` pointer when it's null! 