### PR TITLE
MER-3406 Attempt to silence some warnings in the perfetto project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ if (MSVC)
             /bigobj # only needed for compilation of perfetto itself
             /wd4267 # silence C4267 warning
                     # perfetto.cc(41285): warning C4267: '=': conversion from 'size_t' to 'uint8_t' 
-			        # perfetto.cc(51874): warning C4267: 'initializing': conversion from 'size_t' to '_Ty2', possible loss of data
+                    # perfetto.cc(51874): warning C4267: 'initializing': conversion from 'size_t' to '_Ty2', possible loss of data
             /wd4996 # silence C4996 warning
                     # perfetto.cc(45932): warning C4996: 'std::atomic_store_explicit': warning STL4029
                     # perfetto.cc(47835): warning C4996: 'std::atomic_load_explicit': warning STL4029

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,10 +71,16 @@ if (MSVC)
     target_compile_options(perfetto
         PRIVATE
             /bigobj # only needed for compilation of perfetto itself
+            /wd4267 # silence C4267 warning
+                    # perfetto.cc(41285): warning C4267: '=': conversion from 'size_t' to 'uint8_t' 
+			        # perfetto.cc(51874): warning C4267: 'initializing': conversion from 'size_t' to '_Ty2', possible loss of data
+            /wd4996 # silence C4996 warning
+                    # perfetto.cc(45932): warning C4996: 'std::atomic_store_explicit': warning STL4029
+                    # perfetto.cc(47835): warning C4996: 'std::atomic_load_explicit': warning STL4029
         PUBLIC
             /Zc:__cplusplus # we need the correct value of the __cplusplus macro
             /permissive- # see https://github.com/google/perfetto/issues/214
-        )
+    )
 endif ()
 
 add_library(perfetto::perfetto ALIAS perfetto)


### PR DESCRIPTION
This silences two warnings generated in MSVC by the `perfetto` project in `melatonin_perfetto`:

```
2023-04-23T10:45:49.1156848Z   Building Custom Rule C:/actions-runner/_work/MerlinLib/MerlinLib/melatonin_perfetto/CMakeLists.txt
2023-04-23T10:45:49.4187488Z   perfetto.cc
2023-04-23T10:46:01.1413507Z C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\tuple(660,1): warning C4267: '=': conversion from 'size_t' to 'uint8_t', possible loss of data [C:\actions-runner\_work\MerlinLib\MerlinLib\build\melatonin_perfetto\perfetto.vcxproj]
2023-04-23T10:46:01.1447702Z C:\actions-runner\_work\MerlinLib\MerlinLib\build\_deps\perfetto-src\sdk\perfetto.cc(41285): message : see reference to function template instantiation 'std::tuple<size_t &,uint8_t &> &std::tuple<size_t &,uint8_t &>::operator =<size_t,size_t,0>(std::pair<size_t,size_t> &&) noexcept' being compiled [C:\actions-runner\_work\MerlinLib\MerlinLib\build\melatonin_perfetto\perfetto.vcxproj]
2023-04-23T10:46:01.1451296Z C:\actions-runner\_work\MerlinLib\MerlinLib\build\_deps\perfetto-src\sdk\perfetto.cc(41285): message : see reference to function template instantiation 'std::tuple<size_t &,uint8_t &> &std::tuple<size_t &,uint8_t &>::operator =<size_t,size_t,0>(std::pair<size_t,size_t> &&) noexcept' being compiled [C:\actions-runner\_work\MerlinLib\MerlinLib\build\melatonin_perfetto\perfetto.vcxproj]
2023-04-23T10:46:01.1658838Z C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\memory(3772,10): warning C4996: 'std::atomic_store_explicit': warning STL4029: std::atomic_*() overloads for shared_ptr are deprecated in C++20. The shared_ptr specialization of std::atomic provides superior functionality. You can define _SILENCE_CXX20_OLD_SHARED_PTR_ATOMIC_SUPPORT_DEPRECATION_WARNING or _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS to acknowledge that you have received this warning. [C:\actions-runner\_work\MerlinLib\MerlinLib\build\melatonin_perfetto\perfetto.vcxproj]
2023-04-23T10:46:01.1662866Z C:\actions-runner\_work\MerlinLib\MerlinLib\build\_deps\perfetto-src\sdk\perfetto.cc(45932): message : see reference to function template instantiation 'void std::atomic_store<perfetto::ProducerEndpoint>(std::shared_ptr<perfetto::ProducerEndpoint> *,std::shared_ptr<perfetto::ProducerEndpoint>)' being compiled [C:\actions-runner\_work\MerlinLib\MerlinLib\build\melatonin_perfetto\perfetto.vcxproj]
2023-04-23T10:46:01.2180087Z C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\memory(3758,17): warning C4996: 'std::atomic_load_explicit': warning STL4029: std::atomic_*() overloads for shared_ptr are deprecated in C++20. The shared_ptr specialization of std::atomic provides superior functionality. You can define _SILENCE_CXX20_OLD_SHARED_PTR_ATOMIC_SUPPORT_DEPRECATION_WARNING or _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS to acknowledge that you have received this warning. [C:\actions-runner\_work\MerlinLib\MerlinLib\build\melatonin_perfetto\perfetto.vcxproj]
2023-04-23T10:46:01.2184728Z C:\actions-runner\_work\MerlinLib\MerlinLib\build\_deps\perfetto-src\sdk\perfetto.cc(47835): message : see reference to function template instantiation 'std::shared_ptr<perfetto::ProducerEndpoint> std::atomic_load<perfetto::ProducerEndpoint>(const std::shared_ptr<perfetto::ProducerEndpoint> *)' being compiled [C:\actions-runner\_work\MerlinLib\MerlinLib\build\melatonin_perfetto\perfetto.vcxproj]
2023-04-23T10:46:01.2532432Z C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\utility(249,55): warning C4267: 'initializing': conversion from 'size_t' to '_Ty2', possible loss of data [C:\actions-runner\_work\MerlinLib\MerlinLib\build\melatonin_perfetto\perfetto.vcxproj]
2023-04-23T10:46:01.2533818Z           with
2023-04-23T10:46:01.2534138Z           [
2023-04-23T10:46:01.2534447Z               _Ty2=uint32_t
2023-04-23T10:46:01.2535375Z           ]
2023-04-23T10:46:01.2537769Z C:\actions-runner\_work\MerlinLib\MerlinLib\build\_deps\perfetto-src\sdk\perfetto.cc(51874): message : see reference to function template instantiation 'std::pair<uint8_t *,uint32_t>::pair<uint8_t*,unsigned __int64,0>(std::pair<uint8_t *,unsigned __int64> &&) noexcept' being compiled [C:\actions-runner\_work\MerlinLib\MerlinLib\build\melatonin_perfetto\perfetto.vcxproj]
2023-04-23T10:46:01.2542144Z C:\actions-runner\_work\MerlinLib\MerlinLib\build\_deps\perfetto-src\sdk\perfetto.cc(51874): message : see reference to function template instantiation 'std::pair<uint8_t *,uint32_t>::pair<uint8_t*,unsigned __int64,0>(std::pair<uint8_t *,unsigned __int64> &&) noexcept' being compiled [C:\actions-runner\_work\MerlinLib\MerlinLib\build\melatonin_perfetto\perfetto.vcxproj]
2023-04-23T10:46:36.1326977Z   perfetto.vcxproj -> C:\actions-runner\_work\MerlinLib\MerlinLib\build\melatonin_perfetto\Release\perfetto.lib
```